### PR TITLE
Fix: Use astream_chat for ReActAgent streaming

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -32,7 +32,7 @@ async def on_chat_start():
 async def on_message(message: cl.Message):
     """Handles incoming user messages."""
     agent = cl.user_session.get("agent")
-    response = agent.stream_chat(message.content)
+    response = await agent.astream_chat(message.content)
     msg = cl.Message(content="")
     await msg.send()
 


### PR DESCRIPTION
The ReActAgent's stream_chat method was causing an AttributeError. This commit updates the code to use the asynchronous astream_chat method instead, which is the correct method for streaming responses with the current version of LlamaIndex.